### PR TITLE
Added javascript escape option to query

### DIFF
--- a/chuck/src/main/java/com/neuandroid/chuck/NetworkUtils.java
+++ b/chuck/src/main/java/com/neuandroid/chuck/NetworkUtils.java
@@ -17,7 +17,7 @@ import java.util.Scanner;
 
 public class NetworkUtils {
 
-    private static final String CHUCK_QUERY_BASE_URL = "http://api.icndb.com/jokes/random?limitTo=[nerdy]";
+    private static final String CHUCK_QUERY_BASE_URL = "http://api.icndb.com/jokes/random?limitTo=[nerdy]&escape=javascript";
 
 
     private final static String PARAM_FIRST_NAME = "firstName";


### PR DESCRIPTION
This ensures that the returned JSON object doesn't escape HTML characters, but only quotes so we can use it directly in Java.